### PR TITLE
Align naming with ES terminology

### DIFF
--- a/elastic_command
+++ b/elastic_command
@@ -1,7 +1,7 @@
 sbt "run-main edu.berkeley.cs.boom.molly.SyncFTChecker \
     src/test/resources/examples_ft/elastic_search/elastic_search_with_seq.ded \
     src/test/resources/examples_ft/elastic_search/elastic_assert.ded \
-    --EOT 15 \
+    --EOT 17 \
     --EFF 0 \
-    --nodes a,C,c,G,b \
+    --nodes C,n1,n2,n3,M \
     --crashes 1"

--- a/src/test/resources/examples_ft/elastic_search/elastic_assert.ded
+++ b/src/test/resources/examples_ft/elastic_search/elastic_assert.ded
@@ -10,8 +10,8 @@ post("Durability", X, Term, Seq) :-
 
 no_history(X, Seq) :-	
 				ack(C, X, _, _, Term, Seq),               // Client is acknowledged
-				uncrashed_nodes("G", Node),
-				Node != "G",
+				uncrashed_nodes("M", Node),
+				Node != "M",
 				notin history(Node, X, _, Seq);     // Corresponding record not present in ISR history
 
 //AGREEMENT INVAIRANT
@@ -19,16 +19,16 @@ pre("Consistency", X, Maxterm, Seq) :-
 				seq_max(Node, Seq),                  // On some node, the maximum sequence number is "Seq"    
 				term_max(Node, Maxterm),
                 history(Node, X, Maxterm, Seq),        // and payload is "X"
-                uncrashed_nodes("G", Node),      
-				Node != "G", 
+                uncrashed_nodes("M", Node),      
+				Node != "M", 
 				notin clients(Node);
 
 post("Consistency", X, Maxterm, Seq) :- 	
 				seq_max(Node, Seq),
                 term_max(Node, Maxterm),
                 history(Node, X, Maxterm, Seq),
-				uncrashed_nodes("G", Node),
-				Node != "G",
+				uncrashed_nodes("M", Node),
+				Node != "M",
 				notin clients(Node),                
 				notin no_seq_match(Node, Seq),       // then there does not exist a node with a lower seq #
                 notin no_term_match(Node, Maxterm),
@@ -36,23 +36,23 @@ post("Consistency", X, Maxterm, Seq) :-
 
 no_seq_match(Node, Seq) :-
 				seq_max(Node, Seq),
-				uncrashed_nodes("G", Node),
-				uncrashed_nodes("G", Other),
+				uncrashed_nodes("M", Node),
+				uncrashed_nodes("M", Other),
 				Node != Other,
 				notin seq_max(Other, Seq),              // check that max seq # on all nodes is equal
-				Node != "G",
-				Other != "G",
+				Node != "M",
+				Other != "M",
 				notin clients(Node),
 				notin clients(Other);
 
 no_term_match(Node, Term) :-
                 term_max(Node, Term),
-				uncrashed_nodes("G", Node),
-				uncrashed_nodes("G", Other),
+				uncrashed_nodes("M", Node),
+				uncrashed_nodes("M", Other),
 				Node != Other,
 				notin term_max(Other, Term),            // check that max term # on all nodes is equal
-				Node != "G",
-				Other != "G",
+				Node != "M",
+				Other != "M",
 				notin clients(Node),
 				notin clients(Other);
 
@@ -62,10 +62,10 @@ no_payload_match(Node, X1) :-
                 history(Node, X1, Term, Seq),          // check that payloads on all nodes are same
                 history(Other, X2, Term, Seq),
                 X1 != X2,
-                uncrashed_nodes("G", Node), 
-                uncrashed_nodes("G", Other), 
+                uncrashed_nodes("M", Node), 
+                uncrashed_nodes("M", Other), 
                 Node != Other, 
-                Node != "G", 
-                Other != "G",
+                Node != "M", 
+                Other != "M",
                 notin clients(Node),
                 notin clients(Other);

--- a/src/test/resources/examples_ft/elastic_search/elastic_edb.ded
+++ b/src/test/resources/examples_ft/elastic_search/elastic_edb.ded
@@ -1,34 +1,34 @@
 // replica init
 // The "group" relation specifies all prcesses that can ever be part of the group
-group("a", "G")@1;
-group("b", "G")@1;
-group("c", "G")@1;
-group("C", "G")@1;
-group("G", "G")@1;
+group("n1", "M")@1;
+group("n2", "M")@1;
+group("n3", "M")@1;
+group("C", "M")@1;
+group("M", "M")@1;
 group(M, G)@next :- group(M, G);
-group(M, "G") :- 
-		cchange(M, "A", "G"),
-		notin group(M, "G");
+group(M, "M") :- 
+		cchange(M, "A", "M"),
+		notin group(M, "M");
 
 //Used as part of initialisation logic
-begin("a")@1;
-begin("b")@1;
-begin("c")@1;
-begin("G")@1;
+begin("n1")@1;
+begin("n2")@1;
+begin("n3")@1;
+begin("M")@1;
 
 // Nodes are assigned nodeids at the beginning of each run
-nodeid("G", "a", 1)@1;
-nodeid("G", "b", 2)@1;
-nodeid("G", "c", 3)@1;
-nodeid("a", "a", 1)@1;
-nodeid("a", "b", 2)@1;
-nodeid("a", "c", 3)@1;
-nodeid("b", "a", 1)@1;
-nodeid("b", "b", 2)@1;
-nodeid("b", "c", 3)@1;
-nodeid("c", "a", 1)@1;
-nodeid("c", "b", 2)@1;
-nodeid("c", "c", 3)@1;
+nodeid("M", "n1", 1)@1;
+nodeid("M", "n2", 2)@1;
+nodeid("M", "n3", 3)@1;
+nodeid("n1", "n1", 1)@1;
+nodeid("n1", "n2", 2)@1;
+nodeid("n1", "n3", 3)@1;
+nodeid("n2", "n1", 1)@1;
+nodeid("n2", "n2", 2)@1;
+nodeid("n2", "n3", 3)@1;
+nodeid("n3", "n1", 1)@1;
+nodeid("n3", "n2", 2)@1;
+nodeid("n3", "n3", 3)@1;
 nodeid(Node1, Node2, Nodeid)@next :- nodeid(Node1, Node2, Nodeid);
 
 // client init
@@ -36,44 +36,44 @@ clients("C")@1;
 clients(C)@next :- clients(C);
 
 // "primary" designates the primary in the cluster.
-// "member" represents the in-sync replica set at any instant of time
-primary("G", "c")@1;
-primary("a", "c")@1;
-primary("b", "c")@1;
-primary("c", "c")@1;
-primary("C", "c")@1;
+// "in_sync" represents the in-sync replica set at any instant of time
+primary("M", "n1")@1;
+primary("n1", "n1")@1;
+primary("n2", "n1")@1;
+primary("n3", "n1")@1;
+primary("C", "n1")@1;
 
 // Primary node is the first node to be part of ISR
-member("G", "c")@1;
+in_sync("M", "n1")@1;
 
 // write stream.  
-write_request_outgoing("C", "Data1", "c", 1)@2;
-write_request_outgoing("C", "Data2", "b", 2)@7;
+write_request_outgoing("C", "Data1", "n1", 1)@2;
+write_request_outgoing("C", "Data2", "n2", 2)@7;
 
 // Maintain sequence numbers
-seq("a", 1)@1;
-seq("b", 1)@1;
-seq("c", 1)@1;
+seq("n1", 1)@1;
+seq("n2", 1)@1;
+seq("n3", 1)@1;
 seq(Node, Seq)@next :-
-                        member(Node, Node),
+                        in_sync(Node, Node),
                         notin primary(Node, Node),
                         seq(Node, Seq),
                         notin history(Node, _, _, _);
 
 seq(Node, Seq+1)@next :-
-                        member(Node, Node),
+                        in_sync(Node, Node),
                         notin primary(Node, Node),
                         history(Node, _, _, _),
                         max_history(Node, Seq);
 
 max_history(Node, max<Seq>) :-
-                        member(Node, Node),
+                        in_sync(Node, Node),
                         history(Node, _, _, Seq);
 
-term("G", 1)@1;
-term("a", 1)@1;
-term("b", 1)@1;
-term("c", 1)@1;
+term("M", 1)@1;
+term("n1", 1)@1;
+term("n2", 1)@1;
+term("n3", 1)@1;
 term(Node, Term)@next :-
                         term(Node, Term),
                         notin update_term(Node, _);
@@ -96,51 +96,51 @@ updated(G, Term)@next :- updated(G, Term);
 update_term(Node, Term)@async :-
                             group(G, G),
                             update_term(G, Term),
-                            member(G, Node),
+                            in_sync(G, Node),
                             Node !=G;
 
 //Maintain "now" relation
-now("G", 1)@1;
-now("a", 1)@1;
-now("b", 1)@1;
-now("c", 1)@1;
+now("M", 1)@1;
+now("n1", 1)@1;
+now("n2", 1)@1;
+now("n3", 1)@1;
 now("C", 1)@1;
 now(Node, Time+1)@next :- now(Node, Time);
 
 //Initialization logic - some @async are dropped here
 // "establish in-sync replica set membership" as a replica
-member(G, M) :- 
+in_sync(G, M) :- 
 		begin(M),
 		group(M, G);
 
 // Propagate the in-sync replica info to other replicas
-member(M, N) :- 
+in_sync(M, N) :- 
 		group(G, G),
-		member(G, M),
-		member(G, N),
+		in_sync(G, M),
+		in_sync(G, N),
 		M != G,
 		N != G,
 		notin propagate(G, M, N);
 
 propagate(G, M, N)@next :- 	
 			group(G, G),
-			member(G, M),
-			member(G, N),
+			in_sync(G, M),
+			in_sync(G, N),
 			M != G;
 
 // Propagate the in-sync replica info to client
-member(C, M) :- 
+in_sync(C, M) :- 
 		group(G, G), 
-		member(G, M),
+		in_sync(G, M),
 		client(G, C),
 		notin propagate(G, C, M);
 
 propagate(G, C, M)@next :- 	
 			group(G, G),
-			member(G, M),
+			in_sync(G, M),
 			client(G, C);
 
 // Highest unbroken sequence number
-unbroken_seq("a", 0)@1;
-unbroken_seq("b", 0)@1;
-unbroaken_seq("c", 0)@1;
+unbroken_seq("n1", 0)@1;
+unbroken_seq("n2", 0)@1;
+unbroken_seq("n3", 0)@1;

--- a/src/test/resources/examples_ft/elastic_search/elastic_search_with_seq.ded
+++ b/src/test/resources/examples_ft/elastic_search/elastic_search_with_seq.ded
@@ -23,13 +23,13 @@ include "elastic_edb.ded";
 // Keeps track of the uncrashed nodes at every instant
 uncrashed_nodes(G, Node)@next :-
 				group(G, G),
-				member(G, Node),            
+				in_sync(G, Node),            
 				Node != G,
 				notin crash(G, Node, _);
 
 uncrashed_nodes(G, Node)@next :-
 				group(G, G),
-				member(G, Node),
+				in_sync(G, Node),
 				Node != G,
 				crash(G, Node, Time),
 				now(G, Now),
@@ -50,8 +50,8 @@ max_nodeid(G, max<Nodeid>) :-
 // Find the maximum log value on a particular node
 log_max(Node, X, max<Value>) :- log(Node, X, _, Value, _, _);
 
-term_max(Node, max<Term>) :- member(Node, Node), history(Node, _, Term, _);
-seq_max(Node, max<Seq>) :- member(Node, Node), term_max(Node, Term), history(Node, _, Term, Seq);
+term_max(Node, max<Term>) :- in_sync(Node, Node), history(Node, _, Term, _);
+seq_max(Node, max<Seq>) :- in_sync(Node, Node), term_max(Node, Term), history(Node, _, Term, Seq);
 
 // WRITE QUEUE TO PROCESS CONCURRENT WRITES
 //
@@ -124,7 +124,7 @@ write_request_seq_processing(Primary, Data, Origin, Value, Term,  Seq)@next :-
 //When a write_request appears on the primary, for every other replica alive in the system, add to the "replica_write_queue".
 replica_write_queue(Primary, Data, Other, Value, Term, Seq, Nodeid) :-
 								write_request_seq_processing(Primary, Data, _, Value, Term, Seq),
-								member(Primary, Other),
+								in_sync(Primary, Other),
 								Other != Primary,
 								primary(Primary, Primary),
 								nodeid(Primary, Other, Nodeid);
@@ -134,21 +134,21 @@ replica_write_queue(Primary, Data, Other, Value, Term, Seq, Nodeid) :-
 
 // Process the write_request with smallest value first, followed by write with smallest nodeid
 min_replica_val(Node, min<Seq>) :-
-					member(Node, Node),
+					in_sync(Node, Node),
 					replica_write_queue(Node, _, _, _, _, Seq, _);
 
 min_replica_val(Node, 0) :- 
-				member(Node, Node),
+				in_sync(Node, Node),
 				notin replica_write_queue(Node, _, _, _, _, _, _);
 
 min_replica_node( Node, min<Nodeid>) :- 
-					member(Node, Node),
+					in_sync(Node, Node),
 					min_replica_val(Node, Seq),
 					Seq != 0,
 					replica_write_queue(Node, _, _, _, _, Seq, Nodeid);
 
 min_replica_node( Node, 0) :- 
-				member(Node, Node),
+				in_sync(Node, Node),
 				min_replica_val(Node, Seq), Seq == 0;
 
 replica_write_request_outgoing(Primary, Data, Other, Value, Term, Seq, Nodeid) :- 
@@ -187,7 +187,7 @@ replica_write_queue(Node, Data, Origin, Value, Term, Seq, Nodeid)@next :-
 // In case of a primary promotion, all writes logged on the new primary are propagated to all in-sync replicas
 resync_replica_write_queue(Node, Data, Other, Value, Term, Seq, Nodeid, Primaryterm) :- 	
 								log(Node, Data, _, Value, Term, Seq),
-								member(Node, Other),
+								in_sync(Node, Other),
 								Other != Node,
 								primary_to_be(Node),
                                 resync_now(Node),
@@ -215,10 +215,10 @@ resync_now(Node) :-
 
 primary_to_be(Node)@async :- 	
 				promote(G, Node),
-				member(G, Node);
+				in_sync(G, Node);
 
 primary_to_be(Node)@next :-
-                member(Node, Node),
+                in_sync(Node, Node),
                 primary_to_be(Node),
                 notin primary(Node, Node);
 
@@ -227,21 +227,21 @@ primary_to_be(Node)@next :-
 
 // Process the write_request with smallest value first, followed by write with smallest nodeid
 resync_min_replica_val(Node, min<Seq>) :-
-					member(Node, Node),
+					in_sync(Node, Node),
 					resync_replica_write_queue(Node, _, _, _, _, Seq, _, _);
 
 resync_min_replica_val(Node, 0) :- 
-				member(Node, Node),
+				in_sync(Node, Node),
 				notin resync_replica_write_queue(Node, _, _, _, _, _, _, _);
 
 resync_min_replica_node( Node, min<Nodeid>) :- 
-					member(Node, Node),
+					in_sync(Node, Node),
 					resync_min_replica_val(Node, Seq),
 					Seq != 0,
 					resync_replica_write_queue(Node, _, _, _, _, Seq, Nodeid, _);
 
 resync_min_replica_node( Node, 0) :- 
-				    member(Node, Node),
+				    in_sync(Node, Node),
 				    resync_min_replica_val(Node, Seq),
                     Seq == 0;
 
@@ -325,7 +325,7 @@ ack_int(Origin, Data, Replica, Value, Term, Seq)@next :-
 // Before a primary can acknowledge a write, it must receive acknowledgements from all replicas. The following 3 rules ensure the same.
 missing_ack(Primary, Data, Other, Value, Term, Seq) :- 	
 							log(Primary, Data, _, Value, Term, Seq),
-							member(Primary, Other),
+							in_sync(Primary, Other),
 							Primary != Other,
 							notin ack_int(Primary, Data, Other, Value, Term, Seq);
 
@@ -419,11 +419,11 @@ history(Node, Data, Term, Seq)@next :-
 
 // Keep track of highest sequence numbers
 highest_history_seq(Node, max<Seq>) :-
-                        member(Node, Node),
+                        in_sync(Node, Node),
                         history(Node, _, _, Seq);
 
 highest_history_seq(Node, 0) :-
-                        member(Node, Node),
+                        in_sync(Node, Node),
                         notin history(Node, _, _, _);
 
 unbroken_seq(Node, Seq1)@next :-
@@ -440,7 +440,7 @@ trim(Other, Trimseq) :-
                     resync_now(Node),
                     primary_to_be(Node),
                     unbroken_seq(Node, Trimseq),
-                    member(Node, Other), 
+                    in_sync(Node, Other), 
                     Other != "G",
                     Node != Other;
 

--- a/src/test/resources/examples_ft/elastic_search/group.ded
+++ b/src/test/resources/examples_ft/elastic_search/group.ded
@@ -3,17 +3,17 @@
 // is maintained as is.
 view_change(G, M)@next :-	
 				group(G, G),
-				member(G, M),
+				in_sync(G, M),
 				now(G, Now),
 				crash(G, Other, Time),
 				Now == Time,
 				notin crash(G, M, Time);
 
-member(G, M)@next :-		view_change(G, M);
+in_sync(G, M)@next :-		view_change(G, M);
 
-member(G, M)@next :- 		
+in_sync(G, M)@next :- 		
 				group(G, G),
-				member(G, M),
+				in_sync(G, M),
 				notin view_change(G, _);
 
 // view_change_message is the mechanism in which non-global processes learn about changes to the
@@ -30,10 +30,10 @@ view_change_message(C, M)@async :-
 					view_change(G, M),
 					client(G, C);
 
-member(M, N)@next :-	view_change_message(M, N);
+in_sync(M, N)@next :-	view_change_message(M, N);
 
-member(M, N)@next :-			
-			member(M, N),
+in_sync(M, N)@next :-			
+			in_sync(M, N),
 			M != "G",
 			notin view_change_message(M, _);
 
@@ -105,12 +105,12 @@ client(G, C)@next :-
 
 client_known(M, C) :- 	
 			clients(C),
-			member(C, M),
+			in_sync(C, M),
 			notin client_known_reg(C, M);
 
 client_known_reg(C, M)@next :- 	
 				clients(C),
-				member(C, M);
+				in_sync(C, M);
 
 client_known(M, C)@next :- 	
 				client_known(M, C),
@@ -122,12 +122,12 @@ client_known(M, C)@next :-
 				now(G, Now),
 				Now < Time;
 
-// Primry promotion, with the node with the max nodieid being promoted.
+// Primry promotion, with the node with the lowers nodieid being promoted.
 // This is the reverse order to the order in which staggered replica 
 // writes are propagated.
 promote(G, Node) :-	
 			group(G, G),
-			max_nodeid(G, Nodeid),              // max_nodeid is used to promote processes in the 
+			min_nodeid(G, Nodeid),              // min_nodeid is used to promote processes in the 
 			nodeid(G, Node, Nodeid),            // reverse order that replica_writes are staggered
 			primary(G, Primary),
 			Primary !=Node,
@@ -135,7 +135,7 @@ promote(G, Node) :-
 
 promote(G, Node) :- 	
 			group(G, G),
-			max_nodeid(G, Nodeid),
+			min_nodeid(G, Nodeid),
 			nodeid(G, Node, Nodeid),
 			notin primary(G, Node),
             notin promoted(G, Node);


### PR DESCRIPTION
This commit renames some cocepts to be better aligned with ES names. For example, the nodes are now called n1,n2,n3. The concensus oracle is called master. Also, I re-arranged the nodes in the output to have the C,n1,n2,n3 and the primary to be n1 (and future primaries to have a lower order). This gives better graphs.
