### PR TITLE
Adding checkpoint logic

### DIFF
--- a/src/test/resources/examples_ft/elastic_search/v5/cmd
+++ b/src/test/resources/examples_ft/elastic_search/v5/cmd
@@ -1,0 +1,7 @@
+sbt "run-main edu.berkeley.cs.boom.molly.SyncFTChecker \
+ src/test/resources/examples_ft/elastic_search/v5/elastic_search_with_seq.ded \
+ src/test/resources/examples_ft/elastic_search/v5/elastic_assert.ded \
+ --nodes a,b,c,C,G \
+ --EOT 17 \
+ --EFF 0 \
+ --crashes 1"

--- a/src/test/resources/examples_ft/elastic_search/v5/elastic_assert.ded
+++ b/src/test/resources/examples_ft/elastic_search/v5/elastic_assert.ded
@@ -1,0 +1,127 @@
+include "elastic_search_with_seq.ded";
+
+//DURABILITY INVARIANT
+pre("Durability", X, Term, Seq) :-	
+				ack(C, X, _, _, Term, Seq);			// If client is acknowledged
+
+post("Durability", X, Term, Seq) :-	
+				ack(C, X, _, _, Term, Seq),	        // If cliient is acknowledged with payload X and seq number Seq,
+				notin no_history(X, Seq);       // then it is not the case that it is absent from any ISR
+
+no_history(X, Seq) :-	
+				ack(C, X, _, _, Term, Seq),               // Client is acknowledged
+				uncrashed_nodes("G", Node),
+				Node != "G",
+				notin history(Node, X, _, Seq);     // Corresponding record not present in ISR history
+
+//AGREEMENT INVAIRANT
+pre("Consistency", X, Maxterm, Seq) :- 	                    
+				seq_max(Node, Seq),                  // On some node, the maximum sequence number is "Seq"    
+				term_max(Node, Maxterm),
+                history(Node, X, Maxterm, Seq),        // and payload is "X"
+                uncrashed_nodes("G", Node),      
+				Node != "G", 
+				notin clients(Node);
+
+post("Consistency", X, Maxterm, Seq) :- 	
+				seq_max(Node, Seq),
+                term_max(Node, Maxterm),
+                history(Node, X, Maxterm, Seq),
+				uncrashed_nodes("G", Node),
+				Node != "G",
+				notin clients(Node),                
+				notin no_seq_match(Node, Seq),       // then there does not exist a node with a lower seq #
+                notin no_term_match(Node, Maxterm),
+                notin no_payload_match(Node, X);        // or a node for which sequence numbers match, but payloads dont
+
+no_seq_match(Node, Seq) :-
+				seq_max(Node, Seq),
+				uncrashed_nodes("G", Node),
+				uncrashed_nodes("G", Other),
+				Node != Other,
+				notin seq_max(Other, Seq),              // check that max seq # on all nodes is equal
+				Node != "G",
+				Other != "G",
+				notin clients(Node),
+				notin clients(Other);
+
+no_term_match(Node, Term) :-
+                term_max(Node, Term),
+				uncrashed_nodes("G", Node),
+				uncrashed_nodes("G", Other),
+				Node != Other,
+				notin term_max(Other, Term),            // check that max term # on all nodes is equal
+				Node != "G",
+				Other != "G",
+				notin clients(Node),
+				notin clients(Other);
+
+no_payload_match(Node, X1) :-
+                seq_max(Node, Seq),                     // Assuming term and sequence numbers match
+                term_max(Node, Term),
+                history(Node, X1, Term, Seq),          // check that payloads on all nodes are same
+                history(Other, X2, Term, Seq),
+                X1 != X2,
+                uncrashed_nodes("G", Node), 
+                uncrashed_nodes("G", Other), 
+                Node != Other, 
+                Node != "G", 
+                Other != "G",
+                notin clients(Node),
+                notin clients(Other);
+
+// EXTENDED AGREEMENT INVARIANT 
+// Check that all nodes agree on all writes, not only the write with the max seq number
+pre("ExtendedConsistency", X, Term, Seq) :- 	                    
+				member(Node, Node),
+                history(Node, X, Term, Seq),        // for each node, payload is "X"
+                uncrashed_nodes("G", Node),      
+				Node != "G", 
+				notin clients(Node);  
+
+post("ExtendedConsistency", X, Maxterm, Seq) :- 	
+				member(Node, Node),
+                history(Node, X, Maxterm, Seq),
+				uncrashed_nodes("G", Node),
+				Node != "G",
+				notin clients(Node),                
+				notin no_seq_match_extended(Node, Seq),       // then there does not exist a node which seq numbers don't match 
+                notin no_term_match_extended(Node, Maxterm),
+                notin no_payload_match_extended(Node, X);        // or a node for which sequence numbers match, but payloads dont	
+
+no_seq_match_extended(Node, Seq) :-
+				history(Node, X, _, Seq),
+				uncrashed_nodes("G", Node),
+				uncrashed_nodes("G", Other),
+				Node != Other,
+				notin history(Other, X, _, Seq),            // check that seq # on all nodes match
+				X != "NoOp",								// except for writes which are marked NoOp
+				Node != "G",
+				Other != "G",
+				notin clients(Node),
+				notin clients(Other);
+
+no_term_match_extended(Node, Term) :-
+                history(Node, X, Term, Seq),
+				uncrashed_nodes("G", Node),
+				uncrashed_nodes("G", Other),
+				Node != Other,
+				notin history(Other, X, Term, Seq),            // check that term # on all nodes is equal
+				X != "NoOp",
+				Node != "G",
+				Other != "G",
+				notin clients(Node),
+				notin clients(Other);  
+
+no_payload_match_extended(Node, X1) :-
+                history(Node, X1, Term, Seq),          // check that payloads on all nodes are same
+                history(Other, X2, Term, Seq),
+                X1 != X2,
+                uncrashed_nodes("G", Node), 
+                uncrashed_nodes("G", Other), 
+                Node != Other, 
+                Node != "G", 
+                Other != "G",
+                notin clients(Node),
+                notin clients(Other);
+

--- a/src/test/resources/examples_ft/elastic_search/v5/elastic_edb.ded
+++ b/src/test/resources/examples_ft/elastic_search/v5/elastic_edb.ded
@@ -1,0 +1,182 @@
+// replica init
+// The "group" relation specifies all prcesses that can ever be part of the group
+group("a", "G")@1;
+group("b", "G")@1;
+group("c", "G")@1;
+group("C", "G")@1;
+group("G", "G")@1;
+group(M, G)@next :- group(M, G);
+group(M, "G") :- 
+		cchange(M, "A", "G"),
+		notin group(M, "G");
+
+//Used as part of initialisation logic
+begin("a")@1;
+begin("b")@1;
+begin("c")@1;
+begin("G")@1;
+
+// Nodes are assigned nodeids at the beginning of each run
+nodeid("G", "a", 1)@1;
+nodeid("G", "b", 2)@1;
+nodeid("G", "c", 3)@1;
+nodeid("a", "a", 1)@1;
+nodeid("a", "b", 2)@1;
+nodeid("a", "c", 3)@1;
+nodeid("b", "a", 1)@1;
+nodeid("b", "b", 2)@1;
+nodeid("b", "c", 3)@1;
+nodeid("c", "a", 1)@1;
+nodeid("c", "b", 2)@1;
+nodeid("c", "c", 3)@1;
+nodeid(Node1, Node2, Nodeid)@next :- nodeid(Node1, Node2, Nodeid);
+
+// client init
+clients("C")@1;
+clients(C)@next :- clients(C);
+
+// "primary" designates the primary in the cluster.
+// "member" represents the in-sync replica set at any instant of time
+primary("G", "c")@1;
+primary("a", "c")@1;
+primary("b", "c")@1;
+primary("c", "c")@1;
+primary("C", "c")@1;
+
+// Primary node is the first node to be part of ISR
+member("G", "c")@1;
+
+// write stream.  
+write_request_outgoing("C", "Data1", "c", 1)@1;
+write_request_outgoing("C", "Data2", "c", 2)@1;
+
+// Maintain sequence numbers
+seq("a", 1)@1;
+seq("b", 1)@1;
+seq("c", 1)@1;
+seq(Node, Seq)@next :-
+                        member(Node, Node),
+                        notin primary(Node, Node),
+                        seq(Node, Seq),
+                        notin history(Node, _, _, _);
+
+seq(Node, Seq+1)@next :-
+                        member(Node, Node),
+                        notin primary(Node, Node),
+                        history(Node, _, _, _),
+                        max_history(Node, Seq);
+
+max_history(Node, max<Seq>) :-
+                        member(Node, Node),
+                        history(Node, _, _, Seq);
+
+term("G", 1)@1;
+term("a", 1)@1;
+term("b", 1)@1;
+term("c", 1)@1;
+term(Node, Term)@next :-
+                        term(Node, Term),
+                        notin update_term(Node, _);
+
+term(Node, Updated)@next :- update_term(Node, Updated);
+
+update_term(G, Term+1) :-
+                        group(G, G),
+                        promote(G, Node),
+                        term(G, Term),
+                        notin updated(G, Term);
+
+updated(G, Term)@next :-
+                        group(G, G),
+                        promote(G, Node),
+                        term(G, Term);
+
+updated(G, Term)@next :- updated(G, Term);
+
+update_term(Node, Term)@async :-
+                            group(G, G),
+                            update_term(G, Term),
+                            member(G, Node),
+                            Node !=G;
+
+//Maintain "now" relation
+now("G", 1)@1;
+now("a", 1)@1;
+now("b", 1)@1;
+now("c", 1)@1;
+now("C", 1)@1;
+now(Node, Time+1)@next :- now(Node, Time);
+
+//Initialization logic - some @async are dropped here
+// "establish in-sync replica set membership" as a replica
+member(G, M) :- 
+		begin(M),
+		group(M, G);
+
+// Propagate the in-sync replica info to other replicas
+member(M, N) :- 
+		group(G, G),
+		member(G, M),
+		member(G, N),
+		M != G,
+		N != G,
+		notin propagate(G, M, N);
+
+propagate(G, M, N)@next :- 	
+			group(G, G),
+			member(G, M),
+			member(G, N),
+			M != G;
+
+// Propagate the in-sync replica info to client
+member(C, M) :- 
+		group(G, G), 
+		member(G, M),
+		client(G, C),
+		notin propagate(G, C, M);
+
+propagate(G, C, M)@next :- 	
+			group(G, G),
+			member(G, M),
+			client(G, C);
+
+// Local checkpoint is the highest unbroken sequence number which is processed
+local_checkpoint("a", 0)@1;
+local_checkpoint("b", 0)@1;
+
+// Global checkpoint is the minimum of all local checkpoints
+global_checkpoint("c", 0)@1;
+global_checkpoint("a", 0)@1;
+global_checkpoint("b", 0)@1;
+
+replica_checkpoint_info("c", "a", 0)@1;
+replica_checkpoint_info("c", "b", 0)@1;
+
+replica_write_queue_count("c", 0)@1;
+
+// This code is very specific to the current version - we need to find a better
+// way to pick up writes out of order from the replica queue
+// This logic requires 2 writes to be present in replica_write_request_outgoing
+replica_seq_number_processing("c", "a", 1)@1;
+replica_seq_number_processing("c", "b", 2)@1;
+
+replica_seq_number_processing(Primary, Node, Seq+1)@next :-
+                            replica_write_request_outgoing(Primary, _, Node, _, _, Seq, _, _),
+                            replica_seq_number_processing(Primary, Node, Seq),
+                            Node == "a";
+
+replica_seq_number_processing(Primary, Node, Seq-1)@next :-
+                            replica_write_request_outgoing(Primary, _, Node, _, _, Seq, _, _),
+                            replica_seq_number_processing(Primary, Node, Seq),
+                            Node == "b";                                                       
+
+replica_seq_number_processing(Primary, Node, Seq)@next :-
+                            notin replica_write_request_outgoing(Primary, _, Node, _, _, _, _, _),
+                            replica_seq_number_processing(Primary, Node, Seq);
+
+replica_unbroken_sequence_holder("a", 0)@1;
+replica_unbroken_sequence_holder("b", 0)@1;
+
+// Set to 0 to disable batching write requests at replicas
+perform_batching("G", 1)@1;
+perform_batching(G, TrueOrFalse)@next :- perform_batching(G, TrueOrFalse);

--- a/src/test/resources/examples_ft/elastic_search/v5/elastic_search_with_seq.ded
+++ b/src/test/resources/examples_ft/elastic_search/v5/elastic_search_with_seq.ded
@@ -1,0 +1,608 @@
+
+include "group.ded";
+include "elastic_edb.ded";
+
+// At what stage are we?
+// Sequence numbers for non-concurrent writes modeled
+// Trim function implemented after resync operation
+// During resync after a primary crashed, we resend all the writes 
+// from the new primary to the other replicas. This is unnecessary, and
+// introducing checkpoints on the primary and replicas can help cut down 
+// on the number of writes sent out during resync. 
+
+// General comments: 
+// Writes are no longer staggered at the replicas. Also, batching(2 per batch) of writes can be done
+// by  setting perform_batching to 1 in the edb file.
+// _sent tables are typically maintaine dso a message is not sent repeatedly even if the relation that derive it 
+// persist across time. They ensure that there is no retry at any stage.
+// "G" is a global process that has a view of system state that other process do not.
+// group is a global relation which maintains all the processes the could have ever been part of the cluster.
+// member relation maintains the current in-sync replica set of the system.
+// "primary" relation has an entry for each process, which identifies the primary node to each.
+
+// Utilities
+//
+// Keeps track of the uncrashed nodes at every instant
+uncrashed_nodes(G, Node)@next :-
+				group(G, G),
+				member(G, Node),            
+				Node != G,
+				notin crash(G, Node, _);
+
+uncrashed_nodes(G, Node)@next :-
+				group(G, G),
+				member(G, Node),
+				Node != G,
+				crash(G, Node, Time),
+				now(G, Now),
+				Now < Time;
+
+min_val(Node, min<Value>) :- 	write_queue(Node, _, _, Value);
+
+min_nodeid(G, min<Nodeid>) :- 	
+				group(G, G),
+				uncrashed_nodes(G, Node),
+				nodeid(G, Node, Nodeid);
+
+max_nodeid(G, max<Nodeid>) :- 	
+				group(G, G),
+				uncrashed_nodes(G, Node),
+				nodeid(G, Node, Nodeid);
+
+// Find the maximum log value on a particular node
+log_max(Node, X, max<Value>) :- log(Node, X, _, Value, _, _);
+
+term_max(Node, max<Term>) :- member(Node, Node), history(Node, _, Term, _);
+seq_max(Node, max<Seq>) :- member(Node, Node), term_max(Node, Term), history(Node, _, Term, Seq);
+
+// WRITE QUEUE TO PROCESS CONCURRENT WRITES
+//
+// This ensures that a message goes out from client to one of the replicas
+write_request_incoming(Node, Data, Client, Value)@async :- 
+			                        			write_request_outgoing(Client, Data, Node, Value),
+						                        clients(Client);
+
+write_queue(Node, Data, Client, Value) :- 	write_request_incoming(Node, Data, Client, Value);
+
+write_queue(Node, Data, Origin, Value)@next :- 	
+						write_queue(Node, Data, Origin, Value),
+						notin write_dequeue(Node, Data, Origin, Value);
+
+write_request_processing(Node, Data, Origin, Value) :- 	
+						        write_queue(Node, Data, Origin, Value),
+						        min_val(Node, Value);                         // Process request with the lowest value first
+
+write_dequeue(Node, Data, Origin, Value) :- 	write_request_processing(Node, Data, Origin, Value);
+
+write_dequeue(Node, Data, Origin, Value)@next :- write_dequeue(Node, Data, Origin, Value);
+
+// ROUTE TO PRIMARY 
+// When a request on a non-primary, it is forwarded on to the primary. Since there is no retry logic, we keep track of acknowledgements 
+// have been sent out(chain_ack_sent) in order to send out each acknowledgement exactly once. 
+// 
+write_request_processing(Primary, Data, M, Value)@async :-	
+						                write_request_processing(M, Data, _, Value),
+						                primary(M, Primary),
+						                Primary != M;
+
+send_response_to(M, Origin, Value)@next :-
+					write_request_processing(M, _, Origin, Value), 
+					primary(M, Primary),
+					Primary != M;
+
+send_response_to(M, Origin, Value)@next :- 	send_response_to(M, Origin, Value);
+
+//Append sequence number to write request
+
+min_queue_val(Primary, min<Value>) :- 
+                                    primary(Primary, Primary),
+                                    write_request_seq_queue(Primary, _, _, Value);
+
+write_request_seq_queue(Primary, Data, Origin, Value)@next :-
+                                        write_request_processing(Primary, Data, Origin, Value),
+                                        primary(Primary, Primary);
+
+write_request_seq_queue(Primary, Data, Origin, Value)@next :-
+                                        write_request_seq_queue(Primary, Data, Origin, Value),
+                                        notin write_request_seq_dequeue(Primary, Data, Origin, Value);
+
+write_request_seq_dequeue(Primary, Data, Origin, Value) :-
+							            write_request_seq_queue(Primary, Data, Origin, Value),
+                                        min_queue_val(Primary, Value),
+							            primary(Primary, Primary);
+
+write_request_seq_dequeue(Primary, Data, Origin, Value)@next :-
+                                        write_request_seq_dequeue(Primary, Data, Origin, Value);
+
+// Send global checkpoint information to the replicas
+write_request_seq_processing(Primary, Data, Origin, Value, Term,  Seq, GlobalChkPt)@next :-	
+							            write_request_seq_queue(Primary, Data, Origin, Value),
+                                        min_queue_val(Primary, Value),
+							            primary(Primary, Primary),
+							            seq(Primary, Seq),
+                                        term(Primary, Term),
+                                        global_checkpoint(Primary, GlobalChkPt);                                  
+
+//
+// PRIMARY TO REPLICAS.
+//
+//When a write_request appears on the primary, for every other replica alive in the system, add to the "replica_write_queue".
+replica_write_queue(Primary, Data, Other, Value, Term, Seq, Nodeid, GlobalChkPt) :-
+								write_request_seq_processing(Primary, Data, _, Value, Term, Seq, GlobalChkPt),
+								member(Primary, Other),
+								Other != Primary,
+								primary(Primary, Primary),
+								nodeid(Primary, Other, Nodeid);
+
+// Keep track of the number of requests being added to the replica_write_queue
+replica_write_queue_count(Primary, Count+1)@next :- 
+								write_request_seq_processing(Primary, _, _, _, _, _, _),
+								replica_write_queue_count(Primary, Count);	
+
+replica_write_queue_count(Primary, Count)@next :- 
+								notin write_request_seq_processing(Primary, _, _, _, _, _, _),
+								replica_write_queue_count(Primary, Count);	
+
+
+// Replica writes are staggered.
+// This is a priority queue implementation
+
+// Process the write_request with smallest value first, followed by write with smallest nodeid
+min_replica_val(Node, min<Seq>) :-
+					member(Node, Node),
+					replica_write_queue(Node, _, _, _, _, Seq, _, _);
+
+min_replica_val(Node, 0) :- 
+				member(Node, Node),
+				notin replica_write_queue(Node, _, _, _, _, _, _, _);
+
+min_replica_node( Node, min<Nodeid>) :- 
+					member(Node, Node),
+					min_replica_val(Node, Seq),
+					Seq != 0,
+					replica_write_queue(Node, _, _, _, _, Seq, Nodeid, _);
+
+min_replica_node( Node, 0) :- 
+				member(Node, Node),
+				min_replica_val(Node, Seq), Seq == 0;
+
+// Pick a request to send out from the queue
+replica_seq_number_to_dequeue(Primary, Node, SeqNumber) :- 
+								member(Primary, Node),
+								replica_write_queue(Primary, _, Node, _, _, _, _, _),
+								replica_seq_number_processing(Primary, Node, SeqNumber);
+
+// Send out the request only when X number of writes have queued up. This is to model processing
+// requests where the sequence numbers are out of order
+
+should_perform_batching(Primary, PerformBatching) :- 
+								perform_batching(G, PerformBatching),
+								primary(G, Primary);
+
+replica_write_request_outgoing(Primary, Data, Other, Value, Term, Seq, Nodeid, GlobalChkPt) :- 
+								replica_write_queue(Primary, Data, Other, Value, Term, Seq, Nodeid, GlobalChkPt),
+								replica_seq_number_to_dequeue(Primary, Other, Seq),
+								primary(Primary, Primary),
+								replica_write_queue_count(Primary, Count),
+								should_perform_batching(Primary, PerformBatching),
+								PerformBatching == 1,
+								Count == 2;
+
+replica_write_request_outgoing(Primary, Data, Other, Value, Term, Seq, Nodeid, GlobalChkPt) :- 
+								replica_write_queue(Primary, Data, Other, Value, Term, Seq, Nodeid, GlobalChkPt),
+								replica_seq_number_to_dequeue(Primary, Other, Seq),
+								primary(Primary, Primary),
+								should_perform_batching(Primary, PerformBatching),
+								PerformBatching == 0;							
+
+replica_write_request_incoming(Other, Data, Primary, Value, Term, Seq, Nodeid, GlobalChkPt)@async :-
+                                replica_write_request_outgoing(Primary, Data, Other, Value, Term, Seq, Nodeid, GlobalChkPt);
+
+// Based on the request selected for processing, dequeue appropriately. 
+replica_write_dequeue(Primary, Data, Other, Value, Term, Seq, Nodeid, GlobalChkPt) :- 
+                                replica_write_request_outgoing(Primary, Data, Other, Value, Term, Seq, Nodeid, GlobalChkPt);
+
+// This rule in particular is to purge all replica writes cached when the primary node changes/fails
+//
+replica_write_dequeue(Node, Data, Origin, Value, Term, Seq, Nodeid, GlobalChkPt)@next :- 
+									replica_write_queue(Node, Data, Origin, Value, Term, Seq, Nodeid, GlobalChkPt),
+									notin primary(Node, Node),
+									notin primary_to_be(Node),
+									Node != "G";
+
+replica_write_dequeue(Node, Data, Origin, Value, Term, Seq, Nodeid, GlobalChkPt)@next :- 
+                                    replica_write_dequeue(Node, Data, Origin, Value, Term, Seq, Nodeid, GlobalChkPt);
+
+// The request queue consists all queued requests excluding the ones that have been dequeued
+replica_write_queue(Node, Data, Origin, Value, Term, Seq, Nodeid, GlobalChkPt)@next :- 
+									replica_write_queue(Node, Data, Origin, Value, Term, Seq, Nodeid, GlobalChkPt),
+									notin replica_write_dequeue(Node, Data, Origin, Value, Term, Seq, Nodeid, GlobalChkPt);
+
+// NEW PRIMARY TO REPLICAS - in case of primary promotion
+// This is part of the new resync logic and therefore, takes a different processing path than regualr replica_writes
+// The following code is largely similar to the previous queue based processing logic, but the entries have some extra
+// attributes to account for the fact that we are re-syncing the older entries in a new term
+// In case of a primary promotion, all writes logged on the new primary are propagated to all in-sync replicas
+// Only send out writes whose sequence number is greater than the global checkpoint
+ 
+resync_replica_write_queue(Node, Data, Other, Value, Term, Seq, Nodeid, Primaryterm) :- 	
+								log(Node, Data, _, Value, Term, Seq),
+								member(Node, Other),
+								Other != Node,
+								primary_to_be(Node),
+                                resync_now(Node),
+                                term(Node, Primaryterm),
+								nodeid(Node, Other, Nodeid),
+								global_checkpoint(Node, GlobalChkPoint),
+								Seq > GlobalChkPoint;
+
+// The following logic is to couple the change in the primary term sending out the resync messages.
+// We only want to send the resync messages once the primary term has been updated.
+// This logic may be a bit fragile: changes to the promote relation will directly impact the coupling
+max_updated(G, max<Term>) :-
+            group(G, G),
+            update_term(G, Term);
+
+primary_term_compare(Node, Globalterm)@async :-
+                            max_updated(G, Globalterm),
+                            promote(G, Node);
+
+primary_term_compare(Node, Term)@next :-
+                            primary_term_compare(Node, Term);
+
+resync_now(Node) :-
+                primary_term_compare(Node, Globalterm), 
+                term(Node, Term),
+                Globalterm == Term;
+
+primary_to_be(Node)@async :- 	
+				promote(G, Node),
+				member(G, Node);
+
+primary_to_be(Node)@next :-
+                member(Node, Node),
+                primary_to_be(Node),
+                notin primary(Node, Node);
+
+// Resync Replica writes are staggered.
+// This is a priority queue implementation
+
+// The max sequence number of the write in the resync queue  of the new primary: All writes
+// with sequence number greater than this max will be trimmed on the replicas.
+max_seq_number_new_primary(Node, max<Seq>) :- resync_replica_write_queue(Node, _, _, _, _, Seq, _, _);
+
+max_seq_number_new_primary(Node, 0) :-
+					primary_to_be(Node),
+					resync_now(Node),
+					notin resync_replica_write_queue(Node, _, _, _, _, _, _, _);
+
+max_seq_number_new_primary(Node, Seq)@next :-
+					primary(Node, Node),
+					max_seq_number_new_primary(Node, Seq);
+
+
+trim(Other, Trimseq) :-
+                    resync_now(Node),
+                    primary_to_be(Node),
+                    max_seq_number_new_primary(Node, Trimseq),
+                    member(Node, Other), 
+                    Other != "G",
+                    Node != Other;
+
+// A util table to track no-op writes
+resync_replica_writes(Node, Data, Primary, Seq) :- resync_replica_write_queue(Primary, Data, Node, _, _, Seq, _, _);                 
+
+// Process the write_request with smallest value first, followed by write with smallest nodeid
+resync_min_replica_val(Node, min<Seq>) :-
+					member(Node, Node),
+					resync_replica_write_queue(Node, _, _, _, _, Seq, _, _);
+
+resync_min_replica_val(Node, 0) :- 
+				member(Node, Node),
+				notin resync_replica_write_queue(Node, _, _, _, _, _, _, _);
+
+resync_min_replica_node( Node, min<Nodeid>) :- 
+					member(Node, Node),
+					resync_min_replica_val(Node, Seq),
+					Seq != 0,
+					resync_replica_write_queue(Node, _, _, _, _, Seq, Nodeid, _);
+
+resync_min_replica_node( Node, 0) :- 
+				    member(Node, Node),
+				    resync_min_replica_val(Node, Seq),
+                    Seq == 0;
+
+resync_replica_write_request_outgoing(Primary, Data, Other, Value, Term, Seq, Nodeid, Primaryterm) :- 
+								resync_replica_write_queue(Primary, Data, Other, Value, Term, Seq, Nodeid, Primaryterm),
+								resync_min_replica_val(Primary, Seq),
+								primary(Primary, Primary),
+								resync_min_replica_node(Primary, Nodeid);
+
+resync_replica_write_request_incoming(Other, Data, Primary, Value, Term, Seq, Nodeid, Primaryterm)@async :-
+                                resync_replica_write_request_outgoing(Primary, Data, Other, Value, Term, Seq, Nodeid, Primaryterm);
+
+// Based on the request selected for processing, dequeue appropriately. 
+resync_replica_write_dequeue(Primary, Data, Other, Value, Term, Seq, Nodeid, Primaryterm) :- 
+                                resync_replica_write_request_outgoing(Primary, Data, Other, Value, Term, Seq, Nodeid, Primaryterm);
+
+resync_replica_write_dequeue(Node, Data, Origin, Value, Term, Seq, Nodeid, Primaryterm)@next :- 
+                                    resync_replica_write_dequeue(Node, Data, Origin, Value, Term, Seq, Nodeid, Primaryterm);
+
+// The request queue consists all queued requests excluding the ones that have been dequeued
+resync_replica_write_queue(Node, Data, Origin, Value, Term, Seq, Nodeid, Primaryterm)@next :- 
+									resync_replica_write_queue(Node, Data, Origin, Value, Term, Seq, Nodeid, Primaryterm),
+									notin resync_replica_write_dequeue(Node, Data, Origin, Value, Term, Seq, Nodeid, Primaryterm);
+
+// LOGGING WRITES
+// A write is logged at the primary at the same time replica writes are queued and at the replicas when the replica_write is received.
+// While logging writes, we only process incoming requests if the term number of the request is greater than or equsl to that of the 
+// node at which the request is being processed.
+log(Node, Data, Origin, Value, Term, Seq) :- 
+                                        replica_write_request_incoming(Node, Data, Origin, Value, Term, Seq, _, _),
+                                        term(Node, Curterm), 
+                                        Curterm < Term;
+
+log(Node, Data, Origin, Value, Term, Seq) :- 
+                                        replica_write_request_incoming(Node, Data, Origin, Value, Term, Seq, _, _),
+                                        term(Node, Curterm), 
+                                        Curterm == Term;
+
+log(Node, Data, Origin, Value, Term, Seq) :- 
+                                        write_request_seq_processing(Node, Data, Origin, Value, Term, Seq, _),
+                                        primary(Node, Node),
+                                        term(Node, Curterm),
+                                        Curterm < Term;
+
+log(Node, Data, Origin, Value, Term, Seq) :- 
+                                        write_request_seq_processing(Node, Data, Origin, Value, Term, Seq, _),
+                                        primary(Node, Node),
+                                        term(Node, Curterm),
+                                        Curterm == Term;
+
+log(Node, Data, Origin, Value, Term, Seq) :- 
+                                        resync_replica_write_request_incoming(Node, Data, Origin, Value, Term, Seq, _, Primaryterm),
+                                        term(Node, Curterm), 
+                                        Curterm < Primaryterm;
+
+log(Node, Data, Origin, Value, Term, Seq) :- 
+                                        resync_replica_write_request_incoming(Node, Data, Origin, Value, Term, Seq, _, Primaryterm),
+                                        term(Node, Curterm), 
+                                        Curterm == Primaryterm;
+
+log(Node, Data, Origin, Value, Term, Seq)@next :- log(Node, Data, Origin, Value, Term, Seq);
+
+//
+// UPDATE LOCAL AND GLOBAL CHECKPOINT
+//
+// The global checkpoint info is sent by the primary, update it on each replica
+// The local checkpoint on each replica is updated based on the current write received
+//
+
+// This keeps track of the greatest unbroken sequence number on each replica since the local checkpoint
+replica_unbroken_sequence(Replica, SeqNumber) :-
+							replica_unbroken_sequence(Replica, Seq),
+							log(Replica, _, _, _, _, SeqNumber),
+							local_checkpoint(Replica, LocalChkPoint),
+							SeqNumber == Seq+1,
+							Seq > LocalChkPoint-1;					
+
+// The values persist over time
+replica_unbroken_sequence_holder(Replica, Seq)@next :-
+							replica_unbroken_sequence(Replica, Seq);
+
+replica_unbroken_sequence(Replica, Seq) :-
+							member(Replica, Replica),
+							notin primary(Replica, Replica),
+							replica_unbroken_sequence_holder(Replica, Seq);							
+
+// The local checkpoint for each Replica is the max Seq calculated by the above recursive procedure
+local_checkpoint(Replica, max<Seq>) :-
+							member(Replica, Replica),
+							notin primary(Replica, Replica),
+							replica_unbroken_sequence_holder(Replica, Seq);
+
+// The global checkpoint info is received by the primary, and updated on the replicas
+global_checkpoint(Replica, GlobalChkPt)@next :- 
+							member(Replica, Replica),
+							notin primary(Replica, Replica),
+							replica_write_request_incoming(Replica, Data, Origin, Value, Term, Seq, _, GlobalChkPt);
+
+global_checkpoint(Replica, GlobalChkPt)@next :-
+							global_checkpoint(Replica, GlobalChkPt),
+							notin primary(Replica, Replica),
+							notin replica_write_request_incoming(Replica, Data, Origin, Value, Term, Seq, _, _);
+
+//
+// ACKNOWLEDGEMENT LOGIC
+//
+// As soon as a replica_write is received from primary, it is acknowledged.
+// Any write_request that is received but ignored due to an older term# is not acknowledged
+//							
+
+replica_write_response_outgoing(Origin, Data, Replica, Value, Term, Seq, ChkPoint)@async :- 	
+							replica_write_request_incoming(Replica, Data, Origin, Value, Term, Seq, _, _),
+							local_checkpoint(Replica, ChkPoint),
+                            term(Node, Curterm),
+                            Curterm < Term;
+
+replica_write_response_outgoing(Origin, Data, Replica, Value, Term, Seq, ChkPoint)@async :- 	
+							replica_write_request_incoming(Replica, Data, Origin, Value, Term, Seq, _, _),
+							local_checkpoint(Replica, ChkPoint),
+                            term(Node, Curterm),
+                            Curterm == Term;
+
+ack_int(Origin, Data, Replica, Value, Term, Seq)@next :-
+                            replica_write_response_outgoing(Origin, Data, Replica, Value, Term, Seq, _);
+
+// Each replica sends its local checkpoint info to the primary, and this info is used  by 
+// primary to calculate the global checkpoint
+replica_checkpoint_info(Primary, Node, ChkPoint)@next :-
+						member(Primary, Node),
+						primary(Primary, Primary),                // Add this only if the Primary has not crashed
+						replica_write_response_outgoing(Primary, _, Node, _, _, _, ChkPoint);				
+
+replica_checkpoint_info(Primary, Node, ChkPoint)@next :-
+						replica_checkpoint_info(Primary, Node, ChkPoint),
+						primary(Primary, Primary),                             // maintain this info only if the primary has not crashed
+						notin replica_write_response_outgoing(Primary, _, Node, _, _, _, _);
+
+lowest_local_checkpoint(Primary, min<ChkPoint>) :-
+                        	replica_checkpoint_info(Primary, Node, ChkPoint);
+
+// The global checkpoint is the minimum of all local checkpoints
+global_checkpoint(Node, GlobalChkPt) :-
+				primary(Node, Node),
+				lowest_local_checkpoint(Node, GlobalChkPt);
+
+
+// Before a primary can acknowledge a write, it must receive acknowledgements from all replicas. The following 3 rules ensure the same.
+missing_ack(Primary, Data, Other, Value, Term, Seq) :- 	
+							log(Primary, Data, _, Value, Term, Seq),
+							member(Primary, Other),
+							Primary != Other,
+							notin ack_int(Primary, Data, Other, Value, Term, Seq);
+
+write_response_outgoing(Origin, Data, Acker, Value, Term, Seq)@async :- 	
+							log(Acker, Data, Origin, Value, Term, Seq),
+							notin missing_ack(Acker, Data, _, Value, Term, Seq),
+							notin write_response_sent(Acker, Data, Origin, Value, Term, Seq);
+
+write_response_sent(Acker, Data, Origin, Value, Term, Seq)@next :- 
+							log(Acker, Data, Origin, Value, Term, Seq),
+							notin missing_ack(Acker, Data, _, Value, Term, Seq);
+
+// Acknowledgement retrace the forwarding path of the write request
+write_response_outgoing(Origin, Data, Acker, Value, Term, Seq)@async :- 
+							log(Acker, Data, _, Value, Term, Seq),
+							chain_ack(Acker, Data, _, Value, Term, Seq),
+							send_response_to(Acker, Origin, Value),
+							notin write_response_sent(Acker, Data, Origin, Value, Term, Seq);
+
+write_response_sent(Acker, Data, Origin, Value, Term, Seq)@next :- 
+							log(Acker, Data, _, Value, Term, Seq),
+							chain_ack(Acker, Data, _, Value, Term, Seq),
+							send_response_to(Acker, Origin, Value);
+
+chain_ack(Origin, Data, Acker, Value, Term, Seq)@next :-
+                                        write_response_outgoing(Origin, Data, Acker, Value, Term, Seq);
+
+// Acknowledgements persist across time. If a chain_ack is received at a client, the write is acknowledged.
+ack(Origin, Data, Acker, Value, Term, Seq) :-
+					chain_ack(Origin, Data, Acker, Value, Term, Seq),
+					clients(Origin);
+ 
+chain_ack(Origin, Data, Acker, Value, Term, Seq)@next :- chain_ack(Origin, Data, Acker, Value, Term, Seq);
+
+ack_int(Origin, Data, Acker, Value, Term, Seq)@next :- ack_int(Origin, Data, Acker, Value, Term, Seq);
+
+ack(Origin, Data, Acker, Value, Term, Seq)@next :- ack(Origin, Data, Acker, Value, Term, Seq);
+
+// Update sequence number on primary
+seq(Primary, Seq+1)@next :-
+				primary(Primary, Primary),
+				seq(Primary, Seq),
+				write_request_seq_queue(Primary, _, _, _);
+
+seq(Primary, Seq)@next :-
+				primary(Primary, Primary),
+				seq(Primary, Seq),
+				notin write_request_seq_queue(Primary, _, _, _);
+
+// If the incoming write request has a term# >= Current term# on the node, the request is logged.
+history(Node, Data, Term, Seq) :-
+                write_request_seq_processing(Node, Data, _, _, Term, Seq, _),
+                primary(Node, Node),
+                term(Node, Curterm),
+                Curterm < Term;
+
+history(Node, Data, Term, Seq) :-
+                write_request_seq_processing(Node, Data, _, _, Term, Seq, _),
+                primary(Node, Node),
+                term(Node, Curterm),
+                Curterm == Term;
+
+history(Node, Data, Term, Seq) :-
+                replica_write_request_incoming(Node, Data, _, _, Term, Seq, _, _),
+                term(Node, Curterm),
+                Curterm < Term;
+
+history(Node, Data, Term, Seq) :-
+                replica_write_request_incoming(Node, Data, _, _, Term, Seq, _, _),
+                term(Node, Curterm),
+                Curterm == Term;
+
+history(Node, Data, Term, Seq) :- 
+                resync_replica_write_request_incoming(Node, Data, _, _, Term, Seq, _, Primaryterm),
+                term(Node, Curterm), 
+                Curterm < Primaryterm;
+
+history(Node, Data, Term, Seq) :- 
+                resync_replica_write_request_incoming(Node, Data, _, _, Term, Seq, _, Primaryterm),
+                term(Node, Curterm),
+                Curterm == Primaryterm;
+
+history(Node, Data, Term, Seq) :-
+				ack(Node, Data, _, _, Term, Seq),
+				clients(Node);
+
+// History persists across time
+history(Node, Data, Term, Seq)@next :- 
+                        history(Node, Data, Term, Seq),
+                        notin erase_history(Node, Data, Term, Seq),
+                        notin set_noop_history(Node, Data, Term, Seq);
+
+history(Node, "NoOp", Term, Seq)@next :-
+						history(Node, Data, Term, Seq),
+						set_noop_history(Node, Data, Term, Seq);
+
+// Trim history in replicas - remove seq numbers greater than the max seq number in the new primary
+erase_history(Node, Data, Term, Seq) :-
+                    history(Node, Data, Term, Seq),
+                    trim(Node, Trimseq),
+                    Seq > Trimseq;
+
+erase_history(Node, Data, Term, Seq)@next :-
+                    erase_history(Node, Data, Term, Seq);                    
+
+resync_global_checkpoint_holder(Node, Primary, GlobalChkPt) :- 
+					resync_replica_write_queue(Primary, _, Node, _, _, _, _, _), 
+					global_checkpoint(Primary, GlobalChkPt);
+
+// Mark the replica writes which are not present on the new primary as 'NoOp'
+set_noop_history(Node, Data, Term, Seq) :-
+					member(Node, Node),
+					history(Node, Data, Term, Seq),
+					resync_global_checkpoint_holder(Node, Primary, GlobalChkPt),
+					notin resync_replica_writes(Node, _, Primary, Seq),
+					Seq > GlobalChkPt,
+					Node != Primary;
+
+set_noop_history(Node, Data, Term, Seq)@next :-
+                    set_noop_history(Node, Data, Term, Seq);
+
+
+// After resyncing operation, set the global checkpoint as the max sequence number of the new primary
+global_checkpoint(Node, Seq) :-
+				primary(Node, Node),
+				max_seq_number_new_primary(Node, Seq),
+				history(Node, _, _, Seq),                                          // max sequence number is in history
+				resync_replica_write_dequeue(Node, _, _, _, _, Seq, _, _),
+				notin resync_replica_write_queue(Node, _, _, _, _, Seq, _, _);     // This sequence number has been processed
+
+// Set the local checkpoint for each replica to the global checkpoint if it is lower
+// Its possible that the replica has a lower checkpoint than the global checkpoint 
+// after a resync operation, if the replica has gaps in the sequence
+// For example at the beginning of resync, "a" : Data1, -, -   "b" : -, -, Data3 
+// After resync, "a" : NoOp, -, Data3    "b" : -, -, Data3
+// Global checkpoint : 3, Local checkpoint of "a" : 1 - This may never be reset on its own since
+// seq number 2 may never be filled in, in which case the highest unbroken seq number will be 1
+
+replica_unbroken_sequence_holder(Replica, Seq) :- 
+				global_checkpoint(Primary, Seq),
+				max_seq_number_new_primary(Primary, Seq),
+				primary(Primary, Primary),
+				member(Primary, Replica),
+				Replica != Primary;
+
+
+

--- a/src/test/resources/examples_ft/elastic_search/v5/group.ded
+++ b/src/test/resources/examples_ft/elastic_search/v5/group.ded
@@ -1,0 +1,151 @@
+// When a node crashes, the global process "G" peeks into the crash table and sends out a view change
+// message. The member list is only updated on receiving a view_change message. Else, the member list 
+// is maintained as is.
+view_change(G, M)@next :-	
+				group(G, G),
+				member(G, M),
+				now(G, Now),
+				crash(G, Other, Time),
+				Now == Time,
+				notin crash(G, M, Time);
+
+member(G, M)@next :-		view_change(G, M);
+
+member(G, M)@next :- 		
+				group(G, G),
+				member(G, M),
+				notin view_change(G, _);
+
+// view_change_message is the mechanism in which non-global processes learn about changes to the
+// in-sync replica set
+view_change_message(M, N)@async :-	
+					group(G, G),
+					view_change(G, M),
+					view_change(G, N),
+					M != G,
+					N != G;
+
+view_change_message(C, M)@async :- 	
+					group(G, G),
+					view_change(G, M),
+					client(G, C);
+
+member(M, N)@next :-	view_change_message(M, N);
+
+member(M, N)@next :-			
+			member(M, N),
+			M != "G",
+			notin view_change_message(M, _);
+
+// "update_primary" is used to reflect primary promotion
+update_primary(M, Node)@async :-	
+				group(G, G),
+				uncrashed_nodes(G, M),
+				promote(G, Node),
+				notin update_primary_sent(G, M);
+
+update_primary_sent(G, M)@next :- 	
+				group(G, G),
+				uncrashed_nodes(G, M),
+				promote(G, Node);
+
+update_primary(G, Node)@next :- 
+				group(G, G),
+				promote(G, Node);
+
+update_primary(C, Node)@async :- 
+				group(G, G),
+				client(G, C),
+				promote(G, Node),
+				notin update_primary_sent(G, C);
+
+update_primary_sent(G, C)@next :- 	
+				group(G, G),
+				client(G, C),
+				promote(G, Node);
+
+update_primary_sent(G, M)@next :- update_primary_sent(G, M);
+
+// Maintain knowledge of primary across time
+
+primary(M, L)@next :- 	
+			primary(M, L),
+			notin update_primary(M, _),
+			notin crash(M, M, _);
+
+primary(M, L)@next :- 	
+			primary(M, L),
+			notin update_primary(M, _),
+			crash(M, M, Time),
+			now(M, Now),
+			Now < Time;
+
+primary(M, Node)@next :- update_primary(M, Node);
+
+// Clients known to the group "G"
+
+client(G, C) :-	
+		clients(C),
+		group(C, G),
+		notin client_reg(C, G);
+
+client_reg(C, G)@next:-	
+			clients(C),
+			group(C, G);
+
+client(G, C)@next :- 	
+			client(G, C), 
+			notin crash(G, C, _);
+
+client(G, C)@next :- 	
+			client(G, C),
+			crash(G, C, Time),
+			now(G, Now),
+			Now < Time;
+
+client_known(M, C) :- 	
+			clients(C),
+			member(C, M),
+			notin client_known_reg(C, M);
+
+client_known_reg(C, M)@next :- 	
+				clients(C),
+				member(C, M);
+
+client_known(M, C)@next :- 	
+				client_known(M, C),
+				notin crash(M, C, _);
+
+client_known(M, C)@next :-
+				client_known(M, C),
+				crash(M, C, Time),
+				now(G, Now),
+				Now < Time;
+
+// Primry promotion, with the node with the max nodieid being promoted.
+// This is the reverse order to the order in which staggered replica 
+// writes are propagated.
+promote(G, Node) :-	
+			group(G, G),
+			max_nodeid(G, Nodeid),              // max_nodeid is used to promote processes in the 
+			nodeid(G, Node, Nodeid),            // reverse order that replica_writes are staggered
+			primary(G, Primary),
+			Primary !=Node,
+            notin promoted(G, Node);
+
+promote(G, Node) :- 	
+			group(G, G),
+			max_nodeid(G, Nodeid),
+			nodeid(G, Node, Nodeid),
+			notin primary(G, Node),
+            notin promoted(G, Node);
+
+// The "promoted" relation has been introduced to ensure that "promote" message is sent exactly once
+promoted(G, Node)@next :-
+            group(G, G),
+            promote(G, Node);
+
+promoted(G, Node)@next :-
+            promoted(G, Node),
+            uncrashed_nodes(G, Node),
+            notin primary(G, Node);


### PR DESCRIPTION
- Adding local and global checkpoints for replicas and primary
- During resync after a replica is promoted to primary, resync only writes with seq number greater than the global checkpoint
- During resync, trim all writes greater than the max seq number on the new primary
- Batch writes on the replica so that we can test processing writes out of order